### PR TITLE
fix: remove incorrectly allowlisted GHSA-38c4-r59v-3vqw

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -4,7 +4,6 @@
   // Only use one of ["low": true, "moderate": true, "high": true, "critical": true]
   "moderate": true,
   "allowlist": [ // NOTE: Please add as much information as possible to any items added to the allowList
-    "GHSA-38c4-r59v-3vqw",
-    "GHSA-2g4f-4pwh-qvx6" // ajv ReDoS with $data option - transitive via eslint, unfixable without eslint 10.x
+    "GHSA-2g4f-4pwh-qvx6" // ajv ReDoS - transitive via eslint 9's @eslint/eslintrc (uses ajv 6.x API, override to 8.x crashes eslint)
   ]
 }


### PR DESCRIPTION
## Summary
- Removed **GHSA-38c4-r59v-3vqw** (markdown-it ReDoS) from `audit-ci.jsonc` allowlist — `typedoc@0.28.17` already pulls `markdown-it@14.1.1` which is the fixed version. This was never actually vulnerable.
- Updated **GHSA-2g4f-4pwh-qvx6** (ajv ReDoS) comment — confirmed it genuinely cannot be overridden because eslint 9's `@eslint/eslintrc` uses ajv 6.x API internally and overriding to 8.x causes `TypeError: Cannot set properties of undefined (setting 'defaultMeta')`.

## Test plan
- [x] `npm run audit:check` passes
- [x] `npm audit` shows 0 new vulnerabilities (only ajv chain, correctly allowlisted)
- [x] All 41 unit tests pass
- [x] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)